### PR TITLE
Roger edits

### DIFF
--- a/miscellaneous/getDirName.m
+++ b/miscellaneous/getDirName.m
@@ -8,9 +8,11 @@ namePattern = {'cluster00s','group0000','session00','site00'};
 levelEqualName = {'Group/Sort/HighPass/Eye/EyeFilt/Lfp'};
 
 cwd = pwd;
-if(exist(prefdir,'dir')==7)
+%get path of this function
+dpv_prefdir = getPrefDir;
+if(exist(dpv_prefdir,'dir')==7)
     % The preference directory exists
-    cd(prefdir)
+    cd(dpv_prefdir)
     % Check if the user created configuration file is saved in prefdir
     if(ispresent('configuration.txt','file'))
         % Read Configuration.txt file for level information

--- a/miscellaneous/getPrefDir.m
+++ b/miscellaneous/getPrefDir.m
@@ -1,0 +1,9 @@
+function ans = getPrefDir
+    %get path of this function
+    ppdir = mfilename('fullpath');
+    %get the root
+    parts = split(ppdir, filesep);
+    dpv_prefdir_p = join(parts(1:end-2),filesep);
+    dpv_prefdir = dpv_prefdir_p{1};
+    ans = dpv_prefdir;
+end

--- a/miscellaneous/getReturnVal.m
+++ b/miscellaneous/getReturnVal.m
@@ -1,6 +1,7 @@
 function rv = getReturnVal(ReVal, ReValVal)
 
 rvarl = length(ReVal);
+rv = {''};
 if(rvarl>0)
      % assign requested variables to varargout
      for rvi = 1:rvarl

--- a/miscellaneous/levelConvert.m
+++ b/miscellaneous/levelConvert.m
@@ -8,10 +8,10 @@ Args = struct('levelNo','','levelName','');
 
 b_levelName = {'Cluster','Group','Session','Site','Day','Days'};
 cwd = pwd;
-
-if(exist(prefdir,'dir')==7)
+dpv_prefdir = getPrefDir;
+if(exist(dpv_prefdir,'dir')==7)
     % The preference directory exists
-    cd(prefdir)
+    cd(dpv_prefdir)
     % Check if the user created configuration file is saved in prefdir
     if(ispresent('configuration.txt','file'))
         content = textread('configuration.txt','%s');


### PR DESCRIPTION
This proposed change avoids an issue where prefdir is an internal Matlab global variable which contains Matlab's own preferences. I changed it so that the prefdir is the root directory of DPV. I guess we could also do this with global variables, but I've always been a bit wary of those. Any corrections and comments are welcome, of course.