### PR TITLE
Major change in comparing arguments between saved objects and requested objects

### DIFF
--- a/@dirfiles/dirfiles.m
+++ b/@dirfiles/dirfiles.m
@@ -14,8 +14,10 @@ function [obj, varargout] = dirfiles(varargin)
 
 Args = struct('RedoLevels',0, 'SaveLevels',0, 'Auto',0, 'ArgsOnly',0);
 Args.flags = {'Auto','ArgsOnly'};
-% The arguments which can be neglected during arguments checking
-Args.UnimportantArgs = {'RedoLevels','SaveLevels'};                            
+% Specify which arguments should be checked when comparing saved objects
+% to objects that are being asked for. Only arguments that affect the data
+% saved in objects should be listed here.
+Args.DataCheckArgs = {};                            
 
 [Args,modvarargin] = getOptArgs(varargin,Args, ...
 	'subtract',{'RedoLevels','SaveLevels'}, ...

--- a/DPV-Usage.m
+++ b/DPV-Usage.m
@@ -26,7 +26,7 @@ InspectGUI(pf,'overallonly','sessionmeans')
 % now instead of creating the objects session by session, we will use ProcessDays to create all 
 % possible performance objects. And instead of loading pre-saved objects, we are going to recompute
 % both the performance object, and the eyestarget object, which is used to compute performance
-pfpop = ProcessDays(performance,'redolevels',5);
+pfpop = ProcessLevel(performance,'Levels','Days','redolevels',5);
 InspectGUI(pfpop)
 
 % the directories that contained valid data for the performance objects can now be extracted to

--- a/miscellaneous/checkArguments.m
+++ b/miscellaneous/checkArguments.m
@@ -1,22 +1,84 @@
 function n = checkArguments(p,q,varargin)
-% This function is used to check the if the saved Arguments are the same with the ones specified now. 
-% If the two are the same, we can load the saved object directly; if not, we need to create the object 
+% This function is used to check the if the saved arguments in q are the 
+% same as the ones specified now in p. If the two are the same, we can 
+% load the saved object directly. If not, we need to create the object 
 % again using the arguments specified now.
 
 % 'UnimportantArgs' means the arguments whose values can be ignored
 n=0;
-Args = struct('UnimportantArgs','');
+Args = struct('DataCheckArgs','');
 [Args,varargin] = getOptArgs(varargin,Args);
 
-Args.UnimportantArgs = getfield(p,'UnimportantArgs');
+Args.DataCheckArgs = getfield(p,'DataCheckArgs');
+% check if there are no arguments to check
+if(isempty(Args.DataCheckArgs))
+	n = 1;
+	return;
+end
+
 % count indicates the number of arguments with same values
 count = 0;
 
 % Make sure p and q are Args, i.e., structures
 if(isstruct(p)&&isstruct(q))
-    % Get the number of fields (arguments) in the sturct
-    pl = length(fieldnames(p));
-    ql = length(fieldnames(q));
+	% Get an array of field name (argument) for p and q, respectively
+	pa = fieldnames(p);
+	qa = fieldnames(q);
+    % Get the number of fields (arguments) in the struct
+    pl = length(pa);
+    % ql = length(qa);
+	for i = 1:pl
+		pfield = pa{i};
+		% check if this is an argument that should be checked
+		if(sum(strcmp(pfield,Args.DataCheckArgs)) == 1)
+			% check for a match in qa in case the order of the arguments are 
+			% not the same
+			qi = find(strcmp(pfield,qa));
+			if(~isempty(qi))
+				% Get value for this field
+				pp = getfield(p,pfield);
+				qq = getfield(q,qa{qi});
+				k = 0;
+				% Check if the field name is one of the unimportant ones
+				% i.e., the arguments can be ignored
+				% Args can only be one of the following data types
+				if(isempty(pp)&isempty(qq))
+					k = 1;
+				elseif(islogical(pp)&islogical(qq))
+					if(pp==qq)
+						k = 1;
+					end
+				elseif(ischar(pp)&ischar(qq))
+					if(strcmp(pp,qq))
+						k = 1;
+					end
+				elseif(isnumeric(pp)&isnumeric(qq))
+					if(pp==qq)
+						k = 1;
+					end
+				elseif(isstruct(pp)&isstruct(qq))
+					if(checkArguments(pp,qq))
+						k = 1;
+					end
+				elseif(iscell(pp)&iscell(qq))
+					if(checkcell(pp,qq))
+						k = 1;
+					end
+				end
+				count = count + k;
+			end % if(~isempty(qi))
+		end % if(sum(strcmp(pfield,Args.UnimportantArgs) == 0))
+	end % for i = 1:pl
+
+	% if count is equal to the total number of arguments minus that can
+	% be ignored, then return 1
+	if(count==(pl-length(Args.UnimportantArgs)))
+		n = 1;
+	end
+end
+
+%{	
+    
     % Make sure the number of feilds in p and q are the same
     if(pl==ql)
         % Get an array of field name (argument) for p and q, respectively
@@ -65,4 +127,4 @@ if(isstruct(p)&&isstruct(q))
             n = 0;
         end
     end
-end
+%}

--- a/miscellaneous/checkcell.m
+++ b/miscellaneous/checkcell.m
@@ -1,6 +1,7 @@
 function n = checkcell(p,q,varargin)
 % This function is used for checking if two cell arrays are the same.
 
+n = 0;
 count = 0;
 
 if(iscell(p)&&iscell(q))


### PR DESCRIPTION
Major change to check that arguments used to create an object are the same as the ones used in a previously saved object.

checkArguments function has also been modified to make it perform a more thorough check of the arguments as it was failing because of differences in the order that arguments were saved rather than the values of the arguments themselves.

Constructor in the template class dirfiles has been updated to use the new syntax.