### PR TITLE
Added "ObjectLevel' argument.

### DIFF
--- a/@dirfiles/dirfiles.m
+++ b/@dirfiles/dirfiles.m
@@ -12,7 +12,7 @@ function [obj, varargout] = dirfiles(varargin)
 %
 %dependencies: 
 
-Args = struct('RedoLevels',0, 'SaveLevels',0, 'Auto',0, 'ArgsOnly',0);
+Args = struct('RedoLevels',0, 'SaveLevels',0, 'Auto',0, 'ArgsOnly',0, 'ObjectLevel', 'Session');
 Args.flags = {'Auto','ArgsOnly'};
 % Specify which arguments should be checked when comparing saved objects
 % to objects that are being asked for. Only arguments that affect the data


### PR DESCRIPTION
Added "ObjectLevel' argument, which is useful when we want the object to be able to change directories to look for previously saved objects.