### PR TITLE
Update ProcessDirs.m

### DIFF
--- a/@nptdata/ProcessDirs.m
+++ b/@nptdata/ProcessDirs.m
@@ -69,7 +69,8 @@ ndirs = length(sdirs);
 cwd = pwd;
 for i = 1:ndirs
 	fprintf('Processing %s\n',sdirs{i});
-	cd(sdirs{i})
+    pathname = fileparts(sdirs{i});
+	cd(pathname)
     % check for skip.txt
     if(~checkMarkers(obj,Args.RedoValue,'dirs'))
 		if(useObj)


### PR DESCRIPTION
Added a line of code before `cd(sdirs{i})` that essentially goes up one directory (retrieves the path name) to avoid errors when passing paths that point directly to .mat files.  